### PR TITLE
chore: add GitHub issue templates (bug report + feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a bug or unexpected behaviour in time.js
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. Open `index.html` in browser
+2. Click on the date input
+3. ...
+
+## Expected Behaviour
+
+What you expected to happen.
+
+## Actual Behaviour
+
+What actually happened.
+
+## Browser & OS
+
+- Browser: <!-- e.g. Chrome 121 -->
+- OS: <!-- e.g. Windows 11, macOS 14, Ubuntu 22.04 -->
+
+## Screenshots / Console Errors
+
+<!-- Paste any relevant screenshots or browser console errors here -->
+
+## Additional Context
+
+<!-- Any other info that may be helpful -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement for time.js
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem / Motivation
+
+Describe the problem this feature would solve, or the use-case that motivates it.
+
+## Proposed Solution
+
+Describe the feature you'd like. Include any proposed API changes or UI behaviour.
+
+## Alternatives Considered
+
+Any alternative approaches you considered and why you prefer the proposed solution.
+
+## Would you be willing to submit a PR?
+
+- [ ] Yes — I'd like to implement this myself
+- [ ] No — I'd appreciate someone else picking this up
+
+## Additional Context
+
+<!-- Any screenshots, mockups, or links that help illustrate the feature -->


### PR DESCRIPTION
## Description

Adds two GitHub issue templates to standardise how contributors report bugs and request features.

- `.github/ISSUE_TEMPLATE/bug_report.md` — structured template for bug reports (description, reproduction steps, expected vs actual behaviour, browser/OS)
- `.github/ISSUE_TEMPLATE/feature_request.md` — structured template for feature requests (motivation, proposed solution, alternatives, PR willingness)

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

- [x] Verified template YAML front-matter is valid
- [x] Previewed rendered output in GitHub editor