### PR TITLE
fix: correct SA column clipping — table width:100% inside padded wrapper

### DIFF
--- a/time.css
+++ b/time.css
@@ -1,20 +1,27 @@
 /* ==========================================================================
-   time.js — Calendar Widget Styles  (v3 — grid fix):root {
-  --tj-accent: #4f46e5;
-  --tj-accent-dark: #3730a3;
+   time.js — Calendar Widget Styles  (v3 — grid fix)
+   ========================================================================== */
+/* --------------------------------------------------------------------------
+   Design tokens
+   -------------------------------------------------------------------------- */
+:root {
+  --tj-accent:       #4f46e5;
+  --tj-accent-dark:  #3730a3;
   --tj-accent-light: #eef2ff;
-  --tj-today-bg: #6366f1;
-  --tj-sel-bg: #4f46e5;
-  --tj-hover-bg: #e0e7ff;
-  --tj-hover-fg: #3730a3;
-  --tj-sun: #ef4444;
-  --tj-shadow: 0 8px 32px rgba(0,0,0,0.16), 0 2px 8px rgba(0,0,0,0.08);
-  --tj-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --tj-radius: 14px;
-  --tj-w: 296px;
-  --tj-cell: 36px;
+  --tj-today-bg:     #6366f1;
+  --tj-sel-bg:       #4f46e5;
+  --tj-hover-bg:     #e0e7ff;
+  --tj-hover-fg:     #3730a3;
+  --tj-sun:          #ef4444;
+  --tj-shadow:       0 8px 32px rgba(0,0,0,0.16), 0 2px 8px rgba(0,0,0,0.08);
+  --tj-font:         -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --tj-radius:       14px;
+  --tj-w:            296px; /* total picker width */
+  --tj-cell:         36px;  /* day cell size */
 }
-
+/* --------------------------------------------------------------------------
+   Outer container — floats above page, positioned by JS
+   -------------------------------------------------------------------------- */
 .timejs-container {
   position: absolute;
   z-index: 9999;
@@ -26,16 +33,18 @@
   box-shadow: var(--tj-shadow);
   font-family: var(--tj-font);
   overflow: hidden;
+  /* open animation */
   opacity: 0;
   transform: translateY(-8px) scale(0.98);
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
-
 .timejs-container.timejs-open {
   opacity: 1;
   transform: translateY(0) scale(1);
 }
-
+/* --------------------------------------------------------------------------
+   Header bar
+   -------------------------------------------------------------------------- */
 .timejs-header {
   display: flex;
   align-items: center;
@@ -45,7 +54,6 @@
   background: var(--tj-accent);
   user-select: none;
 }
-
 .timejs-header-selects {
   display: flex;
   gap: 6px;
@@ -53,10 +61,14 @@
   flex: 1;
   justify-content: center;
 }
-
-.timejs-month-select, .timejs-year-select {
+/* Month & year dropdowns */
+.timejs-month-select,
+.timejs-year-select {
   appearance: none;
-  background: rgba(255,255,255,0.18) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23fff' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E") no-repeat right 8px center;
+  -webkit-appearance: none;
+  background: rgba(255,255,255,0.18)
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23fff' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E")
+    no-repeat right 8px center;
   color: #fff;
   border: 1px solid rgba(255,255,255,0.35);
   border-radius: 7px;
@@ -66,11 +78,15 @@
   font-family: var(--tj-font);
   cursor: pointer;
   outline: none;
+  transition: background 0.15s;
 }
-
 .timejs-month-select { min-width: 112px; }
-.timejs-year-select { min-width: 70px; }
-
+.timejs-year-select  { min-width: 70px; }
+.timejs-month-select:hover,
+.timejs-year-select:hover  { background-color: rgba(255,255,255,0.28); }
+.timejs-month-select option,
+.timejs-year-select option { background: #fff; color: #111; }
+/* Nav arrows ‹ › */
 .timejs-nav {
   flex-shrink: 0;
   width: 30px;
@@ -83,33 +99,57 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  font-size: 20px;
+  font-size: 22px;
+  line-height: 1;
+  transition: background 0.15s;
 }
-
+.timejs-nav:hover,
+.timejs-nav:focus {
+  background: rgba(255,255,255,0.32);
+  outline: 2px solid rgba(255,255,255,0.5);
+}
+/* --------------------------------------------------------------------------
+   Calendar table
+   FIX: table uses width:100% so it respects the wrapper's horizontal padding.
+   Previously width:var(--tj-w) caused the table to overflow the 8px side
+   padding in .timejs-grid-wrap, clipping the last (SA) column.
+   -------------------------------------------------------------------------- */
 .timejs-table {
-  width: 100%;
-  table-layout: fixed;
+  width: 100%;           /* fills padded wrapper — fixes SA column clipping */
+  table-layout: fixed;   /* forces equal column widths */
   border-collapse: separate;
   border-spacing: 0;
 }
-
-.timejs-grid-wrap { padding: 8px; }
-
-.timejs-table th {
+/* Thin gutter around the grid */
+.timejs-grid-wrap {
+  padding: 6px 8px 4px;
+}
+/* Day-of-week headers */
+.timejs-table thead th {
+  width: calc(100% / 7); /* relative to table width, not container */
   height: 28px;
   text-align: center;
   font-size: 10px;
   font-weight: 700;
   color: #9ca3af;
   text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 4px 0;
 }
-
-.timejs-table td {
+/* All body cells */
+.timejs-table tbody td {
+  width: calc(100% / 7); /* relative to table width, not container */
   height: var(--tj-cell);
   text-align: center;
+  vertical-align: middle;
   padding: 2px 0;
 }
-
+/* Sunday column colour */
+.timejs-sunday { color: var(--tj-sun) !important; }
+/* --------------------------------------------------------------------------
+   Day cells — the circular clickable number
+   .timejs-day is on the inner <span>, NOT on the <td>
+   -------------------------------------------------------------------------- */
 .timejs-day {
   display: inline-flex;
   align-items: center;
@@ -121,352 +161,107 @@
   font-weight: 500;
   color: #374151;
   cursor: pointer;
-  transition: all 0.1s;
+  transition: background 0.1s, color 0.1s, transform 0.1s;
+  user-select: none;
 }
-
-.timejs-day:hover, .timejs-day:focus {
+.timejs-day:hover {
   background: var(--tj-hover-bg);
   color: var(--tj-hover-fg);
-  transform: scale(1.1);
-  outline: none;
+  transform: scale(1.15);
 }
-
-.timejs-sunday { color: var(--tj-sun) !important; }
-
+/* Today */
 .timejs-today {
   background: var(--tj-today-bg) !important;
   color: #fff !important;
-  font-weight: 700;
+  font-weight: 800;
+  box-shadow: 0 2px 6px rgba(99,102,241,0.4);
 }
-
+.timejs-today:hover { background: var(--tj-accent-dark) !important; }
+/* Selected */
 .timejs-selected {
   background: var(--tj-sel-bg) !important;
   color: #fff !important;
-  font-weight: 700;
+  font-weight: 800;
+  box-shadow: 0 2px 10px rgba(79,70,229,0.45);
 }
-
+.timejs-selected:hover { background: var(--tj-accent-dark) !important; }
+/* Today + Selected on same day */
+.timejs-today.timejs-selected {
+  background: var(--tj-accent-dark) !important;
+  box-shadow: 0 2px 10px rgba(55,48,163,0.5);
+}
+/* Empty/padding cells */
+.timejs-table tbody td:not(:has(.timejs-day)) { cursor: default; }
+/* --------------------------------------------------------------------------
+   Footer — Today / Clear
+   -------------------------------------------------------------------------- */
 .timejs-footer {
   display: flex;
   gap: 8px;
-  padding: 10px;
+  padding: 8px 12px 12px;
   background: #fafafa;
   border-top: 1px solid #f0f0f0;
 }
-
 .timejs-btn {
   flex: 1;
   padding: 7px 0;
   border-radius: 8px;
   font-size: 12px;
   font-weight: 700;
+  font-family: var(--tj-font);
   cursor: pointer;
   border: 1.5px solid transparent;
-  transition: all 0.15s;
-}
-
-.timejs-today-btn { background: var(--tj-accent); color: #fff; }
-.timejs-clear-btn { background: #fff; color: #6b7280; border-color: #e5e7eb; }
-
-.timejs-input {
-  width: 100%;
-  max-width: 320px;
-  padding: 11px 14px;
-  font-size: 15px;
-  font-family: var(--tj-font);
-  border: 2px solid #e5e7eb;
-  border-radius: 10px;
-  cursor: pointer;
-  outline: none;
-  transition: all 0.15s;
-}
-
-.timejs-input:hover { border-color: #c4b5fd; }
-.timejs-input.timejs-active { border-color: var(--tj-accent); box-shadow: 0 0 0 3px rgba(79,70,229,0.14); }
-
-.field-hint { display: none; }
-.timejs-active ~ .field-hint { display: flex; }
-   ========================================================================== */
-
-/* --------------------------------------------------------------------------
-   Design tokens
-   -------------------------------------------------------------------------- */
-:root {
-  --tj-accent:        #4f46e5;
-  --tj-accent-dark:   #3730a3;
-  --tj-accent-light:  #eef2ff;
-  --tj-today-bg:      #6366f1;
-  --tj-sel-bg:        #4f46e5;
-  --tj-hover-bg:      #e0e7ff;
-  --tj-hover-fg:      #3730a3;
-  --tj-sun:           #ef4444;
-  --tj-shadow:        0 8px 32px rgba(0,0,0,0.16), 0 2px 8px rgba(0,0,0,0.08);
-  --tj-font:          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --tj-radius:        14px;
-  --tj-w:             296px;  /* total picker width */
-  --tj-cell:          36px;   /* day cell size      */
-}
-
-/* --------------------------------------------------------------------------
-   Outer container — floats above page, positioned by JS
-   -------------------------------------------------------------------------- */
-.timejs-container {
-  position: absolute;
-  z-index:  9999;
-  display:  none;
-  width:    var(--tj-w);
-  background:    #fff;
-  border:        1px solid #e0e0e0;
-  border-radius: var(--tj-radius);
-  box-shadow:    var(--tj-shadow);
-  font-family:   var(--tj-font);
-  overflow: hidden;
-  /* open animation */
-  opacity:    0;
-  transform:  translateY(-8px) scale(0.98);
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-.timejs-container.timejs-open {
-  opacity:   1;
-  transform: translateY(0) scale(1);
-}
-
-/* --------------------------------------------------------------------------
-   Header bar
-   -------------------------------------------------------------------------- */
-.timejs-header {
-  display:         flex;
-  align-items:     center;
-  justify-content: space-between;
-  gap:     6px;
-  padding: 10px;
-  background:  var(--tj-accent);
-  user-select: none;
-}
-.timejs-header-selects {
-  display:         flex;
-  gap:             6px;
-  align-items:     center;
-  flex:            1;
-  justify-content: center;
-}
-
-/* Month & year dropdowns */
-.timejs-month-select,
-.timejs-year-select {
-  appearance: none;
-  -webkit-appearance: none;
-  background: rgba(255,255,255,0.18)
-              url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23fff' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E")
-              no-repeat right 8px center;
-  color:         #fff;
-  border:        1px solid rgba(255,255,255,0.35);
-  border-radius: 7px;
-  padding:       5px 26px 5px 10px;
-  font-size:     13px;
-  font-weight:   600;
-  font-family:   var(--tj-font);
-  cursor:  pointer;
-  outline: none;
-  transition: background 0.15s;
-}
-.timejs-month-select { min-width: 112px; }
-.timejs-year-select  { min-width: 70px;  }
-.timejs-month-select:hover,
-.timejs-year-select:hover  { background-color: rgba(255,255,255,0.28); }
-.timejs-month-select option,
-.timejs-year-select  option { background: #fff; color: #111; }
-
-/* Nav arrows ‹ › */
-.timejs-nav {
-  flex-shrink: 0;
-  width:  30px;
-  height: 30px;
-  background:    rgba(255,255,255,0.18);
-  color:         #fff;
-  border:        1px solid rgba(255,255,255,0.35);
-  border-radius: 7px;
-  display:         flex;
-  align-items:     center;
-  justify-content: center;
-  cursor:      pointer;
-  font-size:   22px;
-  line-height: 1;
-  transition: background 0.15s;
-}
-.timejs-nav:hover,
-.timejs-nav:focus {
-  background: rgba(255,255,255,0.32);
-  outline:    2px solid rgba(255,255,255,0.5);
-}
-
-/* --------------------------------------------------------------------------
-   Calendar table — THE GRID FIX
-
-   CRITICAL: Do NOT put padding/box-sizing on <table>.
-   Instead use border-spacing for internal spacing.
-   table-layout:fixed + explicit column widths = equal 7-column grid.
-   -------------------------------------------------------------------------- */
-.timejs-table {
-  width:            var(--tj-w);
-  table-layout:     fixed;          /* forces equal column widths */
-  border-collapse:  separate;
-  border-spacing:   0;
-  /* NO padding here — it breaks box model for table elements */
-}
-
-/* Thin vertical gutter around the grid via wrapper padding */
-.timejs-grid-wrap {
-  padding: 6px 8px 4px;
-}
-
-/* Day-of-week headers */
-.timejs-table thead th {
-  width:       calc(var(--tj-w) / 7);
-  height:      28px;
-  text-align:  center;
-  font-size:   10px;
-  font-weight: 700;
-  color:       #9ca3af;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 4px 0;
-}
-
-/* All body cells */
-.timejs-table tbody td {
-  width:          calc(var(--tj-w) / 7);
-  height:         var(--tj-cell);
-  text-align:     center;
-  vertical-align: middle;
-  padding:        2px 0;
-}
-
-/* Sunday column colour */
-.timejs-sunday { color: var(--tj-sun) !important; }
-
-/* --------------------------------------------------------------------------
-   Day cells — the circular clickable number
-   .timejs-day is on the inner <span>, NOT on the <td>
-   -------------------------------------------------------------------------- */
-.timejs-day {
-  display:         inline-flex;
-  align-items:     center;
-  justify-content: center;
-  width:         var(--tj-cell);
-  height:        var(--tj-cell);
-  border-radius: 50%;
-  font-size:   13px;
-  font-weight: 500;
-  color:       #374151;
-  cursor:      pointer;
-  transition:  background 0.1s, color 0.1s, transform 0.1s;
-  user-select: none;
-}
-.timejs-day:hover {
-  background: var(--tj-hover-bg);
-  color:      var(--tj-hover-fg);
-  transform:  scale(1.15);
-}
-
-/* Today */
-.timejs-today {
-  background:  var(--tj-today-bg) !important;
-  color:       #fff !important;
-  font-weight: 800;
-  box-shadow:  0 2px 6px rgba(99,102,241,0.4);
-}
-.timejs-today:hover { background: var(--tj-accent-dark) !important; }
-
-/* Selected */
-.timejs-selected {
-  background:  var(--tj-sel-bg) !important;
-  color:       #fff !important;
-  font-weight: 800;
-  box-shadow:  0 2px 10px rgba(79,70,229,0.45);
-}
-.timejs-selected:hover { background: var(--tj-accent-dark) !important; }
-
-/* Today + Selected on same day */
-.timejs-today.timejs-selected {
-  background: var(--tj-accent-dark) !important;
-  box-shadow: 0 2px 10px rgba(55,48,163,0.5);
-}
-
-/* Empty/padding cells */
-.timejs-table tbody td:not(:has(.timejs-day)) { cursor: default; }
-
-/* --------------------------------------------------------------------------
-   Footer — Today / Clear
-   -------------------------------------------------------------------------- */
-.timejs-footer {
-  display: flex;
-  gap:     8px;
-  padding: 8px 12px 12px;
-  background:  #fafafa;
-  border-top:  1px solid #f0f0f0;
-}
-.timejs-btn {
-  flex:    1;
-  padding: 7px 0;
-  border-radius: 8px;
-  font-size:     12px;
-  font-weight:   700;
-  font-family:   var(--tj-font);
-  cursor:  pointer;
-  border:  1.5px solid transparent;
   transition: background 0.15s, color 0.15s, border-color 0.15s, box-shadow 0.15s;
   letter-spacing: 0.02em;
 }
 .timejs-today-btn {
-  background:   var(--tj-accent);
-  color:        #fff;
+  background: var(--tj-accent);
+  color: #fff;
   border-color: var(--tj-accent);
 }
 .timejs-today-btn:hover,
 .timejs-today-btn:focus {
-  background:   var(--tj-accent-dark);
+  background: var(--tj-accent-dark);
   border-color: var(--tj-accent-dark);
-  box-shadow:   0 2px 8px rgba(79,70,229,0.35);
+  box-shadow: 0 2px 8px rgba(79,70,229,0.35);
   outline: none;
 }
 .timejs-clear-btn {
-  background:   #fff;
-  color:        #6b7280;
+  background: #fff;
+  color: #6b7280;
   border-color: #e5e7eb;
 }
 .timejs-clear-btn:hover,
 .timejs-clear-btn:focus {
-  background:   #fef2f2;
-  color:        #b91c1c;
+  background: #fef2f2;
+  color: #b91c1c;
   border-color: #fca5a5;
   outline: none;
 }
-
 /* --------------------------------------------------------------------------
    Input field (used in demo)
    -------------------------------------------------------------------------- */
 .timejs-input {
   display: block;
-  width:   280px;
+  width: 280px;
   padding: 11px 42px 11px 14px;
-  font-size:   15px;
+  font-size: 15px;
   font-family: var(--tj-font);
-  color:       #111827;
+  color: #111827;
   background: #fff
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' fill='none' stroke='%236b7280' stroke-width='1.5' viewBox='0 0 24 24'%3E%3Crect x='3' y='4' width='18' height='18' rx='2'/%3E%3Cpath d='M16 2v4M8 2v4M3 10h18'/%3E%3C/svg%3E")
     no-repeat right 13px center;
-  border:        2px solid #e5e7eb;
+  border: 2px solid #e5e7eb;
   border-radius: 10px;
-  cursor:  pointer;
+  cursor: pointer;
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
   box-sizing: border-box;
 }
 .timejs-input::placeholder { color: #9ca3af; }
-.timejs-input:hover         { border-color: #c4b5fd; }
+.timejs-input:hover { border-color: #c4b5fd; }
 .timejs-input:focus,
 .timejs-input.timejs-active {
   border-color: var(--tj-accent);
-  box-shadow:   0 0 0 3px rgba(79,70,229,0.14);
+  box-shadow: 0 0 0 3px rgba(79,70,229,0.14);
 }
-


### PR DESCRIPTION
## Description

Fixes the last column (SA — Saturday) being clipped by the right edge of the calendar picker.

**Root cause:** `.timejs-table` had `width: var(--tj-w)` (296 px), the same as the outer container. But `.timejs-grid-wrap` applies `padding: 6px 8px 4px`, consuming 16 px of horizontal space. The table therefore overflowed the padded area by 16 px, causing the Saturday column to be cut off at the right border.

**Fix:**
- `width: var(--tj-w)` → `width: 100%` on `.timejs-table` so the table fills only the available (padded) space inside the wrapper.
- `width: calc(var(--tj-w) / 7)` → `width: calc(100% / 7)` on `thead th` and `tbody td` so column widths are relative to the (now-correct) table width.

## Type of Change

- [x] Bug fix (non-breaking — visually corrects clipped last column)

## How Has This Been Tested?

- [x] Opened demo page in browser — all 7 columns (SU through SA) fully visible with equal spacing
- [x] Verified today's date highlight (21) and Saturday column are no longer clipped